### PR TITLE
Add *.{analytics,web}.db.svc.eqiad.wmflabs support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.egg-info/
+.tox/
+__pycache__/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,16 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+sudo: false
+matrix:
+  fast_finish: true
 # command to install dependencies
-install: "pip install tox"
+install: pip install tox-travis
 # command to run tests
 script: tox
 notifications:
   email: false
-  irc: 
+  irc:
     channels:
       - "chat.freenode.net##legoktm"
     skip_join: true

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 
+import os
 import requests
 import unittest
+import unittest.mock
+
 import toolforge
 
 
@@ -32,6 +35,41 @@ class MainTest(unittest.TestCase):
              'tools.mycooltool@tools.wmflabs.org) python-requests/2.13.0'}
         )
         requests.utils.default_user_agent = orig
+
+    def test_connect(self):
+        tests = [
+            (['enwiki_p'], {
+                'database': 'enwiki_p',
+                'host': 'enwiki.web.db.svc.eqiad.wmflabs',
+            }),
+            (['enwiki'], {
+                'database': 'enwiki_p',
+                'host': 'enwiki.web.db.svc.eqiad.wmflabs',
+            }),
+            (['enwiki', 'analytics'], {
+                'database': 'enwiki_p',
+                'host': 'enwiki.analytics.db.svc.eqiad.wmflabs',
+            }),
+            (['enwiki_p', 'labsdb'], {
+                'database': 'enwiki_p',
+                'host': 'enwiki.labsdb',
+            }),
+        ]
+        common_expects = {
+            'read_default_file': os.path.expanduser("~/replica.my.cnf"),
+            'charset': 'utf8mb4',
+        }
+
+        for args, expects in tests:
+            with unittest.mock.patch('toolforge._connect') as mm:
+                mm.return_value = None
+                exp = common_expects.copy()
+                exp.update(expects)
+
+                conn = toolforge.connect(*args)
+
+                assert conn is None
+                mm.assert_called_once_with(**exp)
 
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -17,3 +17,7 @@ basepython = python3
 exclude = .tox
 max_line_length = 120
 ignore = F405
+
+[travis]
+python =
+    3.6: py36, flake8


### PR DESCRIPTION
Add a `cluster` argument to toolforge.connect() that can be used to
select between the web and analytics clusters.

Issue: #1