### PR TITLE
Make it easy to connect to tools.db.svc.eqiad.wmflabs

### DIFF
--- a/toolforge/__init__.py
+++ b/toolforge/__init__.py
@@ -51,15 +51,32 @@ def connect(dbname: str, cluster: str = 'web', **kwargs) -> pymysql.connections.
     return _connect(
         database=dbname + '_p',
         host=host,
-        read_default_file=os.path.expanduser("~/replica.my.cnf"),
-        charset='utf8mb4',
         **kwargs
     )
 
 
 def _connect(*args, **kwargs) -> pymysql.connections.Connection:
     """Wraper for pymysql.connect to make testing easier."""
-    return pymysql.connect(*args, **kwargs)
+    kw = {
+        'read_default_file': os.path.expanduser("~/replica.my.cnf"),
+        'charset': 'utf8mb4',
+    }
+    kw.update(kwargs)
+    return pymysql.connect(*args, **kw)
+
+
+def toolsdb(dbname, **kwargs):
+    """Connect to a database hosted on the toolsdb cluster.
+
+    :param dbname: Database name
+    :param kwargs: For pymysql.connect
+    :return: pymysql connection
+    """
+    return _connect(
+        database=dbname,
+        host='tools.db.svc.eqiad.wmflabs',
+        **kwargs
+    )
 
 
 def dbname(domain: str) -> str:

--- a/toolforge/__init__.py
+++ b/toolforge/__init__.py
@@ -65,7 +65,7 @@ def _connect(*args, **kwargs) -> pymysql.connections.Connection:
     return pymysql.connect(*args, **kw)
 
 
-def toolsdb(dbname, **kwargs):
+def toolsdb(dbname: str, **kwargs) -> pymysql.connections.Connection:
     """Connect to a database hosted on the toolsdb cluster.
 
     :param dbname: Database name


### PR DESCRIPTION
Add a toolforge.toolsdb function that returns a pymysql connection to
a database hosted on the tools.db.svc.eqiad.wmflabs. This cluster is
where Tools can create and manage public or private databases.