### PR TITLE
Add type hints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,10 @@ setup(
     author='Kunal Mehta',
     author_email='legoktm@member.fsf.org',
     description='Small library for common tasks on Wikimedia Toolforge',
-    install_requires=['requests', 'pymysql'],
+    install_requires=[
+        'requests',
+        'pymysql',
+        'typing;python_version<"3.5"'
+    ],
     test_suite="tests",
 )

--- a/toolforge/__init__.py
+++ b/toolforge/__init__.py
@@ -110,7 +110,7 @@ def set_user_agent(tool, url=None, email=None):
 
     requests_ua = requests.utils.default_user_agent()
     ua = '{} ({}; {}) {}'.format(tool, url, email, requests_ua)
-    requests.utils.default_user_agent = lambda: ua
+    requests.utils.default_user_agent = lambda *args, **kwargs: ua
     return ua
 
 

--- a/toolforge/__init__.py
+++ b/toolforge/__init__.py
@@ -62,7 +62,7 @@ def _connect(*args, **kwargs) -> pymysql.connections.Connection:
     return pymysql.connect(*args, **kwargs)
 
 
-def dbname(domain: str) -> Optional[str]:
+def dbname(domain: str) -> str:
     """
     Convert a domain/URL into its database name
     """
@@ -83,7 +83,8 @@ def dbname(domain: str) -> Optional[str]:
             for special in data[num]:
                 if special['url'] == domain:
                     return special['dbname']
-    return None
+
+    raise ValueError('Unable to find database name')
 
 
 @functools.lru_cache()

--- a/toolforge/__init__.py
+++ b/toolforge/__init__.py
@@ -20,9 +20,10 @@ import functools
 import os
 import pymysql
 import requests
+from typing import Optional
 
 
-def connect(dbname, cluster='web', **kwargs):
+def connect(dbname: str, cluster: str = 'web', **kwargs) -> pymysql.connections.Connection:
     """
     Get a database connection for the
     specified wiki
@@ -56,12 +57,12 @@ def connect(dbname, cluster='web', **kwargs):
     )
 
 
-def _connect(*args, **kwargs):
+def _connect(*args, **kwargs) -> pymysql.connections.Connection:
     """Wraper for pymysql.connect to make testing easier."""
     return pymysql.connect(*args, **kwargs)
 
 
-def dbname(domain):
+def dbname(domain: str) -> Optional[str]:
     """
     Convert a domain/URL into its database name
     """
@@ -82,6 +83,7 @@ def dbname(domain):
             for special in data[num]:
                 if special['url'] == domain:
                     return special['dbname']
+    return None
 
 
 @functools.lru_cache()
@@ -93,7 +95,7 @@ def _fetch_sitematrix():
     return r.json()
 
 
-def set_user_agent(tool, url=None, email=None):
+def set_user_agent(tool: str, url: Optional[str] = None, email: Optional[str] = None) -> str:
     """
     Set the default requests user-agent to a better
     one in accordance with
@@ -114,7 +116,7 @@ def set_user_agent(tool, url=None, email=None):
     return ua
 
 
-def redirect_to_https():
+def redirect_to_https() -> None:
     """
     Deprecated: All requests are now redirected to HTTPS by
     Toolforge itself.

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,20 @@
 [tox]
 
 # Environements to execute when invoking 'tox'
-envlist = py{34,35,36,37}-{flake8,test}
+envlist = py{34,35,36,37}-{flake8,mypy,test}
 skip_missing_interpreters = True
 
 [testenv]
 deps=
     test: pytest
     test: pytest-mock
+    # mypy is pinned because we need to support 3.4 still
+    mypy: mypy<0.700
     flake8: flake8
 
 commands=
     test: pytest
+    mypy: mypy toolforge/
     flake8: flake8
 
 [flake8]


### PR DESCRIPTION
Includes two code changes (one of them in a separate commit), the rest is just annotations.

I’m not sure about the optional return type for `dbname`, though… will that be annoying for callers who just want to assume they never pass invalid domains into the function? (I haven’t used that function yet, so I don’t know.)