### PR TITLE
Require pymysql<1.0 for python 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ setup(
     install_requires=[
         'requests',
         'pymysql<0.10;python_version<"3.5"',
-        'pymysql;python_version>="3.5"',
+        'pymysql<1.0;python_version=="3.5"',
+        'pymysql;python_version>="3.6"',
         'typing;python_version<"3.5"'
     ],
     python_requires='>=3.4',


### PR DESCRIPTION
Pymysql dropped python 3.5 support in version 1.0.0, but did not add it
as a requirement until 1.0.1. This means that pip sees 1.0.0 as the
newest version satisfying dependency requirements, but 1.0.0 does not
run on python 3.5.
See https://github.com/PyMySQL/PyMySQL/blob/master/CHANGELOG.md